### PR TITLE
Setup Fathom for PushState navigation

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -52,6 +52,7 @@
     })(document, window, '//cdn.usefathom.com/tracker.js', 'fathom');
     fathom('set', 'siteId', '<%= VUE_APP_FATHOM_SITE_ID || "" %>');
     fathom("trackPageview");
+    fathom('set', 'spa', 'pushstate');
   </script>
   <!-- / Fathom -->
   <% } %>

--- a/src/router.js
+++ b/src/router.js
@@ -38,11 +38,4 @@ const router = new Router({
   }
 })
 
-// Track additional page views after app loads
-router.afterEach((to) => {
-  if (window.fathom) {
-    window.fathom("trackPageview", { path: to.path })
-  }
-})
-
 export default router


### PR DESCRIPTION
As per https://usefathom.com/support/tracking, for SPA's using PushState for navigation, you need to setup Fathom accordingly to count page views correctly.