### PR TITLE
100 modules is not enough

### DIFF
--- a/src/graphql/GitHubRepos.gql
+++ b/src/graphql/GitHubRepos.gql
@@ -5,7 +5,7 @@ query($ghLogin:String!){
     login
     avatarUrl
     bioHTML
-    repositories(first:100, ownerAffiliations: [OWNER, ORGANIZATION_MEMBER, COLLABORATOR]) {
+    repositories(first:1000, ownerAffiliations: [OWNER, ORGANIZATION_MEMBER, COLLABORATOR]) {
       nodes {
         id
         viewerCanAdminister


### PR DESCRIPTION
I have nearly 1000 modules, I would have increased to 10000 but didn't want to propose too big a change.

I want to archive the modules that I am no longer interested in maintaining. there are hundreds of them. I did successfully use your app to archive the first hundred, it was great! but then because I only archived them and did not delete them, they came back in the next query. so I couldn't get past the first hundred. I guessed there was a limit somewhere in the code and I found this.