### PR TITLE
show private repos in orgs

### DIFF
--- a/src/graphql/GitHubRepos.gql
+++ b/src/graphql/GitHubRepos.gql
@@ -8,6 +8,7 @@ query($ghLogin: String!, $after: String) {
     repositories(
       first: 100
       after: $after
+      affiliations: [OWNER, ORGANIZATION_MEMBER, COLLABORATOR]
       ownerAffiliations: [OWNER, ORGANIZATION_MEMBER, COLLABORATOR]
     ) {
       totalCount


### PR DESCRIPTION

https://docs.github.com/en/rest/reference/repos#list-repositories-for-the-authenticated-user--parameters
RESTful API
`affiliation`
Default: owner,collaborator,organization_member

seems GraphQL interface does not show the same. add it manually to make sure all repos are shown in UI.