### PR TITLE
ci: speed up CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
       - name: Install Playwright Browsers
-        run: bunx playwright install --with-deps
+        run: bunx playwright install chromium --with-deps
       - name: Run Playwright tests
         run: bunx playwright test --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
         env:
@@ -82,7 +82,7 @@ jobs:
   build:
     timeout-minutes: 10
     runs-on: ubuntu-latest
-    needs: [lint-and-test, e2e-tests]
+    needs: [lint-and-test]
     steps:
       - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@v2

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -15,7 +15,7 @@ export default defineConfig({
   retries: process.env.CI ? 2 : 0,
 
   // Opt out of parallel tests on CI.
-  workers: process.env.CI ? 1 : undefined,
+  workers: process.env.CI ? 2 : undefined,
 
   // Reporter to use
   reporter: [


### PR DESCRIPTION
## Summary

Speed up CI by utilizing available resources better. Uses 2 Playwright workers on CI (matching the 2 vCPUs on GitHub Actions runners), installs only chromium instead of all browsers (it's the only one we test against), and runs the build job in parallel with E2E tests instead of waiting for them.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] Other (describe below)

CI performance optimization

## Checklist

- [x] `bun run lint` passes
- [x] `bun run test:unit` passes
- [x] `bun run build` succeeds
- [ ] New components have co-located tests
- [ ] Uses semantic color classes (not hardcoded Tailwind colors)
- [ ] Type-only imports for `@octokit/*` types