### PR TITLE
feat(analytics): standardize Fathom events to dot notation

### DIFF
--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -9,6 +9,7 @@ import { GenerateReposButton } from "@/components/generate-repos-button";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button, buttonVariants } from "@/components/ui/button";
 import { useGitHubData } from "@/hooks/use-github-data";
+import { analytics } from "@/utils/analytics";
 
 const homeLinks = [
   { href: "#features", label: "Features" },
@@ -323,6 +324,7 @@ export default function Header() {
   const isDevelopment = import.meta.env.DEV;
 
   function handleLogout() {
+    analytics.trackLogout();
     logout();
     // Force full reload to clear SWR cache and React state
     window.location.href = "/";

--- a/src/components/landing/get-started-section.tsx
+++ b/src/components/landing/get-started-section.tsx
@@ -83,7 +83,6 @@ function InlinePATForm() {
     if (!isValid || isValidating) return;
 
     setPat(token, remember);
-    analytics.trackTokenValidated();
     void navigate("/dashboard");
   }
 
@@ -264,6 +263,7 @@ export function GetStartedSection() {
                     <a
                       className="inline-flex items-center gap-2 px-4 py-2.5 rounded-lg bg-emerald-600 text-white text-sm font-medium hover:bg-emerald-700 transition-colors shadow-sm"
                       href={step.cta.href}
+                      onClick={() => analytics.trackGeneratePATClick()}
                       rel="noopener noreferrer"
                       target="_blank"
                     >

--- a/src/components/landing/hero-section.tsx
+++ b/src/components/landing/hero-section.tsx
@@ -3,6 +3,7 @@ import { ArrowRight, Check } from "lucide-react";
 
 import { GithubIcon } from "@/components/icons";
 
+import { analytics } from "@/utils/analytics";
 import { fadeUp, staggerContainer } from "@/utils/motion";
 
 export function HeroSection() {
@@ -53,6 +54,7 @@ export function HeroSection() {
           <motion.button
             className="w-full sm:w-auto inline-flex items-center justify-center gap-2 px-8 py-3 sm:py-3.5 rounded-lg bg-[var(--brand-blue)] text-white font-medium text-sm sm:text-base hover:opacity-90 transition-opacity shadow-sm"
             onClick={() => {
+              analytics.trackHeroCTAClick();
               const target = document.getElementById("get-started");
               target?.scrollIntoView({ behavior: "smooth" });
             }}

--- a/src/components/scroll-button.test.tsx
+++ b/src/components/scroll-button.test.tsx
@@ -7,7 +7,7 @@ import ScrollButton from "./scroll-button";
 // Mock the analytics module
 vi.mock("@/utils/analytics", () => ({
   analytics: {
-    trackGetStartedClick: vi.fn(),
+    trackCTAScrollClick: vi.fn(),
   },
 }));
 
@@ -23,9 +23,7 @@ describe("ScrollButton", () => {
   });
 
   test("renders button with children", () => {
-    render(
-      <ScrollButton targetId="test-section">Click Me</ScrollButton>
-    );
+    render(<ScrollButton targetId="test-section">Click Me</ScrollButton>);
 
     const button = screen.getByRole("button", { name: /click me/i });
     expect(button).toBeInTheDocument();
@@ -35,7 +33,7 @@ describe("ScrollButton", () => {
     render(
       <ScrollButton className="custom-class" targetId="test-section">
         Test
-      </ScrollButton>
+      </ScrollButton>,
     );
 
     const button = screen.getByRole("button", { name: /test/i });
@@ -46,7 +44,7 @@ describe("ScrollButton", () => {
     render(
       <ScrollButton color="danger" targetId="test-section">
         Test
-      </ScrollButton>
+      </ScrollButton>,
     );
 
     const button = screen.getByRole("button", { name: /test/i });
@@ -58,7 +56,7 @@ describe("ScrollButton", () => {
     render(
       <ScrollButton size="sm" targetId="test-section">
         Test
-      </ScrollButton>
+      </ScrollButton>,
     );
 
     const button = screen.getByRole("button", { name: /test/i });
@@ -69,7 +67,7 @@ describe("ScrollButton", () => {
     render(
       <ScrollButton targetId="test-section" variant="bordered">
         Test
-      </ScrollButton>
+      </ScrollButton>,
     );
 
     const button = screen.getByRole("button", { name: /test/i });
@@ -86,9 +84,7 @@ describe("ScrollButton", () => {
     const scrollIntoViewMock = vi.fn();
     targetElement.scrollIntoView = scrollIntoViewMock;
 
-    render(
-      <ScrollButton targetId="target-section">Scroll Down</ScrollButton>
-    );
+    render(<ScrollButton targetId="target-section">Scroll Down</ScrollButton>);
 
     const button = screen.getByRole("button", { name: /scroll down/i });
     await user.click(button);
@@ -98,9 +94,7 @@ describe("ScrollButton", () => {
   });
 
   test("handles non-existent target element gracefully", async () => {
-    render(
-      <ScrollButton targetId="non-existent-id">Click Me</ScrollButton>
-    );
+    render(<ScrollButton targetId="non-existent-id">Click Me</ScrollButton>);
 
     const button = screen.getByRole("button", { name: /click me/i });
 
@@ -118,14 +112,14 @@ describe("ScrollButton", () => {
     document.body.appendChild(targetElement);
 
     render(
-      <ScrollButton targetId="github-token-form">Get Started</ScrollButton>
+      <ScrollButton targetId="github-token-form">Get Started</ScrollButton>,
     );
 
     const button = screen.getByRole("button", { name: /get started/i });
     await user.click(button);
 
     // Verify analytics was tracked
-    expect(analytics.trackGetStartedClick).toHaveBeenCalledTimes(1);
+    expect(analytics.trackCTAScrollClick).toHaveBeenCalledTimes(1);
   });
 
   test("does not track analytics for other target IDs", async () => {
@@ -137,21 +131,17 @@ describe("ScrollButton", () => {
     targetElement.scrollIntoView = vi.fn();
     document.body.appendChild(targetElement);
 
-    render(
-      <ScrollButton targetId="other-section">Click Me</ScrollButton>
-    );
+    render(<ScrollButton targetId="other-section">Click Me</ScrollButton>);
 
     const button = screen.getByRole("button", { name: /click me/i });
     await user.click(button);
 
     // Verify analytics was NOT tracked
-    expect(analytics.trackGetStartedClick).not.toHaveBeenCalled();
+    expect(analytics.trackCTAScrollClick).not.toHaveBeenCalled();
   });
 
   test("uses default props when not specified", () => {
-    render(
-      <ScrollButton targetId="test">Default Button</ScrollButton>
-    );
+    render(<ScrollButton targetId="test">Default Button</ScrollButton>);
 
     const button = screen.getByRole("button", { name: /default button/i });
 
@@ -160,9 +150,7 @@ describe("ScrollButton", () => {
   });
 
   test("is accessible with proper button role", () => {
-    render(
-      <ScrollButton targetId="test">Accessible Button</ScrollButton>
-    );
+    render(<ScrollButton targetId="test">Accessible Button</ScrollButton>);
 
     const button = screen.getByRole("button", { name: /accessible button/i });
     expect(button).toBeInTheDocument();

--- a/src/components/scroll-button.tsx
+++ b/src/components/scroll-button.tsx
@@ -114,9 +114,9 @@ export default function ScrollButton({
   variant = "solid",
 }: ScrollButtonProps) {
   const handleClick = () => {
-    // Track "Get Started" clicks when scrolling to the token form
+    // Track CTA clicks when scrolling to the token form
     if (targetId === "github-token-form") {
-      analytics.trackGetStartedClick();
+      analytics.trackCTAScrollClick();
     }
 
     scrollToID(targetId);

--- a/src/components/token-form-section.tsx
+++ b/src/components/token-form-section.tsx
@@ -3,7 +3,6 @@ import { useNavigate } from "react-router-dom";
 
 import GitHubTokenForm from "@/components/github-token-form";
 import { useGitHubData } from "@/hooks/use-github-data";
-import { analytics } from "@/utils/analytics";
 
 export default function TokenFormSection() {
   // Pre-populate with dev token if available (development only)
@@ -16,10 +15,6 @@ export default function TokenFormSection() {
 
   const handleSubmit = (token: string, remember: boolean) => {
     setPat(token, remember);
-
-    // Track successful token validation
-    analytics.trackTokenValidated();
-
     void navigate("/dashboard");
   };
 

--- a/src/github/mutations.test.ts
+++ b/src/github/mutations.test.ts
@@ -7,6 +7,7 @@ vi.mock("@/utils/analytics", () => ({
     trackRepoArchived: vi.fn(),
     trackRepoDeleted: vi.fn(),
   },
+  resetSessionTracking: vi.fn(),
 }));
 
 import { analytics } from "@/utils/analytics";

--- a/src/hooks/use-confirmation-modal.ts
+++ b/src/hooks/use-confirmation-modal.ts
@@ -146,10 +146,13 @@ export function useConfirmationModal({
     });
 
     if (action === "archive") {
-      analytics.trackArchiveActionSubmitted(repos.length);
+      analytics.trackArchiveSubmit(repos.length);
     } else {
-      analytics.trackDeleteActionSubmitted(repos.length);
+      analytics.trackDeleteSubmit(repos.length);
     }
+
+    let processed = 0;
+    let errorCount = 0;
 
     for (const repo of repos) {
       if (abortRef.current) break;
@@ -176,6 +179,7 @@ export function useConfirmationModal({
           payload: { error, repository: repo },
           type: "ADD_ERROR",
         });
+        errorCount++;
 
         if (thrown instanceof RequestError && thrown.status === 401) {
           debug.error(
@@ -184,12 +188,22 @@ export function useConfirmationModal({
           break;
         }
       } finally {
+        processed++;
         dispatch({
           payload: { increment: 1, repo: repo.name },
           type: "UPDATE_PROGRESS",
         });
-        await new Promise((resolve) => setTimeout(resolve, 1000));
+        if (!abortRef.current) {
+          await new Promise((resolve) => setTimeout(resolve, 1000));
+        }
       }
+    }
+
+    // Track batch outcome
+    if (abortRef.current) {
+      analytics.trackBatchStopped(processed);
+    } else {
+      analytics.trackBatchCompleted(processed - errorCount);
     }
 
     dispatch({ type: "COMPLETE_PROCESSING" });

--- a/src/hooks/use-token-validation.ts
+++ b/src/hooks/use-token-validation.ts
@@ -1,6 +1,7 @@
 import { RequestError } from "@octokit/request-error";
 import { useEffect, useRef, useState } from "react";
 
+import { analytics } from "@/utils/analytics";
 import { createThrottledOctokit, isValidGitHubToken } from "@/github/client";
 import { checkTokenScopes, SCOPE_DESCRIPTIONS } from "@/github/scopes";
 
@@ -76,6 +77,7 @@ export function useTokenValidation(token: string): TokenValidationResult {
             setUsername(null);
             setScopeWarnings([]);
             lastValidatedTokenRef.current = token;
+            analytics.trackTokenFailed();
 
             const status = err instanceof RequestError ? err.status : undefined;
 

--- a/src/providers/github-data-provider.test.tsx
+++ b/src/providers/github-data-provider.test.tsx
@@ -22,6 +22,7 @@ vi.mock("@/utils/analytics", () => ({
   analytics: {
     trackTokenValidated: vi.fn(),
   },
+  resetSessionTracking: vi.fn(),
 }));
 
 vi.mock("@/utils/debug", () => ({
@@ -314,7 +315,7 @@ describe("GitHubDataProvider", () => {
       expect(analytics.trackTokenValidated).toHaveBeenCalledTimes(1);
     });
 
-    it("does not fire trackTokenValidated twice on SWR revalidation", async () => {
+    it("calls trackTokenValidated on each successful fetch (dedup handled by analytics module)", async () => {
       setupSuccessfulFetch();
 
       const { result } = renderHook(() => useGitHubData(), {
@@ -342,8 +343,8 @@ describe("GitHubDataProvider", () => {
         expect(result.current.repos).not.toBeNull();
       });
 
-      // Should still be called only once — ref guards against duplicates
-      expect(analytics.trackTokenValidated).toHaveBeenCalledTimes(1);
+      // Provider calls on every success — once-per-session dedup is in analytics module
+      expect(analytics.trackTokenValidated).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/src/providers/github-data-provider.tsx
+++ b/src/providers/github-data-provider.tsx
@@ -60,7 +60,6 @@ export const GitHubDataProvider: React.FC<GitHubProviderProps> = ({
   );
   const [progressiveUser, setProgressiveUser] = useState<null | User>(null);
   const lastFetchTimeRef = useRef<number>(0);
-  const tokenValidatedRef = useRef<null | string>(null);
 
   // Load from secure storage on mount
   useLayoutEffect(() => {
@@ -132,9 +131,8 @@ export const GitHubDataProvider: React.FC<GitHubProviderProps> = ({
         if (data.user?.login && !login) {
           setLogin(data.user.login);
         }
-        // Track token validation once per token (not on revalidation)
-        if (pat && tokenValidatedRef.current !== pat) {
-          tokenValidatedRef.current = pat;
+        // Track token validation (once-per-session handled by analytics registry)
+        if (pat) {
           analytics.trackTokenValidated();
         }
         // Clear progress when complete
@@ -204,7 +202,6 @@ export const GitHubDataProvider: React.FC<GitHubProviderProps> = ({
     setPatState(null);
     setProgressiveRepos(null);
     setProgressiveUser(null);
-    tokenValidatedRef.current = null;
     if (typeof window !== "undefined") {
       try {
         secureStorage.removeItem("login");

--- a/src/utils/analytics.test.ts
+++ b/src/utils/analytics.test.ts
@@ -12,11 +12,12 @@ import { trackEvent } from "fathom-client";
 
 import { debug } from "@/utils/debug";
 
-import { analytics, track } from "./analytics";
+import { analytics, resetSessionTracking, track } from "./analytics";
 
 describe("track", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    resetSessionTracking();
   });
 
   afterEach(() => {
@@ -25,31 +26,85 @@ describe("track", () => {
 
   describe("in development mode (default test env)", () => {
     it("logs dev message and does not call trackEvent", () => {
-      track("test_event");
+      track("dashboard.user.logout");
 
       expect(debug.log).toHaveBeenCalledWith(
-        "[DEV] Would track event: test_event",
+        "[Analytics] Would track: dashboard.user.logout",
         "",
       );
       expect(trackEvent).not.toHaveBeenCalled();
     });
 
     it("logs dev message with value when provided", () => {
-      track("test_event", 5);
+      track("dashboard.action.archive_submit", 5);
 
       expect(debug.log).toHaveBeenCalledWith(
-        "[DEV] Would track event: test_event",
+        "[Analytics] Would track: dashboard.action.archive_submit",
         "(value: 5)",
       );
       expect(trackEvent).not.toHaveBeenCalled();
     });
 
     it("logs value=0 correctly (not falsy-skipped)", () => {
-      track("test_event", 0);
+      track("dashboard.action.delete_submit", 0);
 
       expect(debug.log).toHaveBeenCalledWith(
-        "[DEV] Would track event: test_event",
+        "[Analytics] Would track: dashboard.action.delete_submit",
         "(value: 0)",
+      );
+    });
+  });
+
+  describe("once-per-session tracking", () => {
+    it("fires once-per-session events only once", () => {
+      track("auth.token.validated");
+      track("auth.token.validated");
+
+      // First call logs the event, second logs skip message
+      expect(debug.log).toHaveBeenCalledTimes(2);
+      expect(debug.log).toHaveBeenNthCalledWith(
+        1,
+        "[Analytics] Would track: auth.token.validated",
+        "",
+      );
+      expect(debug.log).toHaveBeenNthCalledWith(
+        2,
+        "[Analytics] Skipped (already fired): auth.token.validated",
+      );
+    });
+
+    it("fires non-once events every time", () => {
+      track("dashboard.user.logout");
+      track("dashboard.user.logout");
+
+      expect(debug.log).toHaveBeenCalledTimes(2);
+      expect(debug.log).toHaveBeenNthCalledWith(
+        1,
+        "[Analytics] Would track: dashboard.user.logout",
+        "",
+      );
+      expect(debug.log).toHaveBeenNthCalledWith(
+        2,
+        "[Analytics] Would track: dashboard.user.logout",
+        "",
+      );
+    });
+
+    it("resetSessionTracking allows once events to fire again", () => {
+      track("auth.token.validated");
+      resetSessionTracking();
+      track("auth.token.validated");
+
+      // Both should be "Would track" (no skip)
+      expect(debug.log).toHaveBeenNthCalledWith(
+        1,
+        "[Analytics] Would track: auth.token.validated",
+        "",
+      );
+      expect(debug.log).toHaveBeenNthCalledWith(
+        2,
+        "[Analytics] Would track: auth.token.validated",
+        "",
       );
     });
   });
@@ -63,23 +118,29 @@ describe("track", () => {
 
     it("calls trackEvent with event name only when no value", async () => {
       const { track: prodTrack } = await import("./analytics");
-      prodTrack("test_event");
+      prodTrack("dashboard.user.logout");
 
-      expect(trackEvent).toHaveBeenCalledWith("test_event");
+      expect(trackEvent).toHaveBeenCalledWith("dashboard.user.logout");
     });
 
     it("calls trackEvent with _value when value is provided", async () => {
       const { track: prodTrack } = await import("./analytics");
-      prodTrack("test_event", 10);
+      prodTrack("dashboard.action.archive_submit", 10);
 
-      expect(trackEvent).toHaveBeenCalledWith("test_event", { _value: 10 });
+      expect(trackEvent).toHaveBeenCalledWith(
+        "dashboard.action.archive_submit",
+        { _value: 10 },
+      );
     });
 
     it("calls trackEvent with _value when value is 0", async () => {
       const { track: prodTrack } = await import("./analytics");
-      prodTrack("test_event", 0);
+      prodTrack("dashboard.action.delete_submit", 0);
 
-      expect(trackEvent).toHaveBeenCalledWith("test_event", { _value: 0 });
+      expect(trackEvent).toHaveBeenCalledWith(
+        "dashboard.action.delete_submit",
+        { _value: 0 },
+      );
     });
 
     it("swallows trackEvent errors and logs via debug.warn", async () => {
@@ -89,7 +150,7 @@ describe("track", () => {
       });
 
       const { track: prodTrack } = await import("./analytics");
-      expect(() => prodTrack("test_event")).not.toThrow();
+      expect(() => prodTrack("dashboard.user.logout")).not.toThrow();
 
       expect(debug.warn).toHaveBeenCalledWith("Failed to track event:", error);
     });
@@ -99,28 +160,45 @@ describe("track", () => {
 describe("analytics convenience methods", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    resetSessionTracking();
   });
 
-  it("trackArchiveActionSubmitted passes correct event name and count", () => {
-    analytics.trackArchiveActionSubmitted(3);
+  it("trackArchiveSubmit passes correct event name and count", () => {
+    analytics.trackArchiveSubmit(3);
     expect(debug.log).toHaveBeenCalledWith(
-      "[DEV] Would track event: archive_action_submitted",
+      "[Analytics] Would track: dashboard.action.archive_submit",
       "(value: 3)",
     );
   });
 
-  it("trackDeleteActionSubmitted passes correct event name and count", () => {
-    analytics.trackDeleteActionSubmitted(5);
+  it("trackDeleteSubmit passes correct event name and count", () => {
+    analytics.trackDeleteSubmit(5);
     expect(debug.log).toHaveBeenCalledWith(
-      "[DEV] Would track event: delete_action_submitted",
+      "[Analytics] Would track: dashboard.action.delete_submit",
       "(value: 5)",
     );
   });
 
-  it("trackGetStartedClick passes correct event name", () => {
-    analytics.trackGetStartedClick();
+  it("trackCTAScrollClick passes correct event name", () => {
+    analytics.trackCTAScrollClick();
     expect(debug.log).toHaveBeenCalledWith(
-      "[DEV] Would track event: get_started_click",
+      "[Analytics] Would track: landing.cta.scroll_click",
+      "",
+    );
+  });
+
+  it("trackHeroCTAClick passes correct event name", () => {
+    analytics.trackHeroCTAClick();
+    expect(debug.log).toHaveBeenCalledWith(
+      "[Analytics] Would track: landing.cta.hero_click",
+      "",
+    );
+  });
+
+  it("trackGeneratePATClick passes correct event name", () => {
+    analytics.trackGeneratePATClick();
+    expect(debug.log).toHaveBeenCalledWith(
+      "[Analytics] Would track: landing.generate_pat.click",
       "",
     );
   });
@@ -128,7 +206,7 @@ describe("analytics convenience methods", () => {
   it("trackRepoArchived passes correct event name and value 1", () => {
     analytics.trackRepoArchived();
     expect(debug.log).toHaveBeenCalledWith(
-      "[DEV] Would track event: repo_archived",
+      "[Analytics] Would track: dashboard.repo.archived",
       "(value: 1)",
     );
   });
@@ -136,7 +214,7 @@ describe("analytics convenience methods", () => {
   it("trackRepoDeleted passes correct event name and value 1", () => {
     analytics.trackRepoDeleted();
     expect(debug.log).toHaveBeenCalledWith(
-      "[DEV] Would track event: repo_deleted",
+      "[Analytics] Would track: dashboard.repo.deleted",
       "(value: 1)",
     );
   });
@@ -144,7 +222,39 @@ describe("analytics convenience methods", () => {
   it("trackTokenValidated passes correct event name", () => {
     analytics.trackTokenValidated();
     expect(debug.log).toHaveBeenCalledWith(
-      "[DEV] Would track event: token_validated",
+      "[Analytics] Would track: auth.token.validated",
+      "",
+    );
+  });
+
+  it("trackTokenFailed passes correct event name", () => {
+    analytics.trackTokenFailed();
+    expect(debug.log).toHaveBeenCalledWith(
+      "[Analytics] Would track: auth.token.failed",
+      "",
+    );
+  });
+
+  it("trackBatchCompleted passes correct event name and count", () => {
+    analytics.trackBatchCompleted(8);
+    expect(debug.log).toHaveBeenCalledWith(
+      "[Analytics] Would track: dashboard.batch.completed",
+      "(value: 8)",
+    );
+  });
+
+  it("trackBatchStopped passes correct event name and count", () => {
+    analytics.trackBatchStopped(3);
+    expect(debug.log).toHaveBeenCalledWith(
+      "[Analytics] Would track: dashboard.batch.stopped",
+      "(value: 3)",
+    );
+  });
+
+  it("trackLogout passes correct event name", () => {
+    analytics.trackLogout();
+    expect(debug.log).toHaveBeenCalledWith(
+      "[Analytics] Would track: dashboard.user.logout",
       "",
     );
   });

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -1,26 +1,92 @@
-// Fathom Analytics utilities for privacy-first event tracking
-// Uses modern trackEvent API (2024+) instead of deprecated trackGoal
-// Page views are handled automatically by FathomAnalytics component
+// Fathom Analytics — typed event registry with dot-notation naming
+// Uses fathom-client trackEvent API. Page views handled by FathomAnalytics component.
+// Naming convention: page.element.action (project-hub standard)
 
 import { trackEvent } from "fathom-client";
 
 import { debug } from "@/utils/debug";
 
-// Configuration constants
+// --- Event Registry ---
+
+interface FathomEventConfig {
+  readonly once?: boolean; // Default: false (fire every time)
+  readonly description: string;
+}
+
+const FATHOM_EVENTS = {
+  // Landing page
+  "landing.cta.hero_click": {
+    description: 'User clicked the hero "Start Cleaning Up" button',
+    once: true,
+  },
+  "landing.cta.scroll_click": {
+    description: "User clicked a CTA that scrolls to the token form",
+    once: true,
+  },
+  "landing.generate_pat.click": {
+    description: 'User clicked the "Generate PAT on GitHub" external link',
+    once: true,
+  },
+
+  // Auth flow
+  "auth.token.failed": {
+    description:
+      "GitHub PAT validation failed (invalid format or API rejection)",
+  },
+  "auth.token.validated": {
+    description: "GitHub PAT validated successfully via API",
+    once: true,
+  },
+
+  // Dashboard actions
+  "dashboard.action.archive_submit": {
+    description: "User confirmed bulk archive action",
+  },
+  "dashboard.action.delete_submit": {
+    description: "User confirmed bulk delete action",
+  },
+  "dashboard.batch.completed": {
+    description: "Batch operation completed (all repos processed)",
+  },
+  "dashboard.batch.stopped": {
+    description: "User stopped a batch operation before completion",
+  },
+  "dashboard.repo.archived": {
+    description: "Single repository archived successfully",
+  },
+  "dashboard.repo.deleted": {
+    description: "Single repository deleted successfully",
+  },
+  "dashboard.user.logout": {
+    description: "User clicked logout",
+  },
+} as const satisfies Record<string, FathomEventConfig>;
+
+type FathomEventName = keyof typeof FATHOM_EVENTS;
+
+// --- Once-per-session tracking ---
+
+const firedThisSession = new Set<FathomEventName>();
+
+// --- Core tracking function ---
+
 const IS_PRODUCTION = import.meta.env.PROD;
 
-/**
- * Track user events using modern Fathom trackEvent API
- *
- * @param eventName - Descriptive event name (no special characters)
- * @param value - Optional value for counting (e.g., number of repos)
- */
-export function track(eventName: string, value?: number): void {
+function track(eventName: FathomEventName, value?: number): void {
+  const config = FATHOM_EVENTS[eventName] as FathomEventConfig;
+  const once = config.once ?? false;
+
+  if (once && firedThisSession.has(eventName)) {
+    debug.log(`[Analytics] Skipped (already fired): ${eventName}`);
+    return;
+  }
+
   if (!IS_PRODUCTION) {
     debug.log(
-      `[DEV] Would track event: ${eventName}`,
+      `[Analytics] Would track: ${eventName}`,
       value !== undefined ? `(value: ${value})` : "",
     );
+    if (once) firedThisSession.add(eventName);
     return;
   }
 
@@ -30,46 +96,70 @@ export function track(eventName: string, value?: number): void {
     } else {
       trackEvent(eventName);
     }
+    if (once) firedThisSession.add(eventName);
   } catch (error) {
     debug.warn("Failed to track event:", error);
   }
 }
 
-/**
- * Pre-defined event tracking functions for common user actions
- */
+// --- Legacy event bridge ---
+// Also fire old snake_case names so Fathom keeps accumulating historical data.
+// Remove once the old events are no longer needed for reporting.
+
+function trackLegacy(legacyName: string, value?: number): void {
+  if (!IS_PRODUCTION) return; // dev logging already handled by track()
+  try {
+    if (value !== undefined) {
+      trackEvent(legacyName, { _value: value });
+    } else {
+      trackEvent(legacyName);
+    }
+  } catch {
+    // Swallow — legacy tracking is best-effort
+  }
+}
+
+// --- Convenience API ---
+
 export const analytics = {
-  /**
-   * Track when user submits bulk archive action
-   * @param repoCount - Number of repositories being archived
-   */
-  trackArchiveActionSubmitted: (repoCount: number) =>
-    track("archive_action_submitted", repoCount),
-
-  /**
-   * Track when user submits bulk delete action
-   * @param repoCount - Number of repositories being deleted
-   */
-  trackDeleteActionSubmitted: (repoCount: number) =>
-    track("delete_action_submitted", repoCount),
-
-  /**
-   * Track when user clicks "Get Started" CTA buttons
-   */
-  trackGetStartedClick: () => track("get_started_click"),
-
-  /**
-   * Track individual repository archived (for total counting)
-   */
-  trackRepoArchived: () => track("repo_archived", 1),
-
-  /**
-   * Track individual repository deleted (for total counting)
-   */
-  trackRepoDeleted: () => track("repo_deleted", 1),
-
-  /**
-   * Track successful GitHub token validation
-   */
-  trackTokenValidated: () => track("token_validated"),
+  trackArchiveSubmit: (repoCount: number) => {
+    track("dashboard.action.archive_submit", repoCount);
+    trackLegacy("archive_action_submitted", repoCount);
+  },
+  trackBatchCompleted: (successCount: number) =>
+    track("dashboard.batch.completed", successCount),
+  trackBatchStopped: (processedCount: number) =>
+    track("dashboard.batch.stopped", processedCount),
+  trackCTAScrollClick: () => {
+    track("landing.cta.scroll_click");
+    trackLegacy("get_started_click");
+  },
+  trackDeleteSubmit: (repoCount: number) => {
+    track("dashboard.action.delete_submit", repoCount);
+    trackLegacy("delete_action_submitted", repoCount);
+  },
+  trackGeneratePATClick: () => track("landing.generate_pat.click"),
+  trackHeroCTAClick: () => track("landing.cta.hero_click"),
+  trackLogout: () => track("dashboard.user.logout"),
+  trackRepoArchived: () => {
+    track("dashboard.repo.archived", 1);
+    trackLegacy("repo_archived", 1);
+  },
+  trackRepoDeleted: () => {
+    track("dashboard.repo.deleted", 1);
+    trackLegacy("repo_deleted", 1);
+  },
+  trackTokenFailed: () => track("auth.token.failed"),
+  trackTokenValidated: () => {
+    track("auth.token.validated");
+    trackLegacy("token_validated");
+  },
 };
+
+// Exported for testing
+export { FATHOM_EVENTS, track };
+export type { FathomEventName };
+
+export function resetSessionTracking(): void {
+  firedThisSession.clear();
+}


### PR DESCRIPTION
## Summary

Migrate all Fathom analytics events from ad-hoc `snake_case` names to the project-hub `page.element.action` dot-notation standard. Adds a typed event registry with compile-time validation and once-per-session tracking. Fixes the `token_validated` triple-fire bug (was firing from 2 form handlers + provider). Adds 6 new events for previously untracked actions (logout, batch complete/stop, hero CTA, generate PAT link, token validation failure). Legacy snake_case event names are dual-fired in production for historical continuity.

### Event name mapping

| Old Name | New Name |
|---|---|
| `archive_action_submitted` | `dashboard.action.archive_submit` |
| `delete_action_submitted` | `dashboard.action.delete_submit` |
| `get_started_click` | `landing.cta.scroll_click` |
| `repo_archived` | `dashboard.repo.archived` |
| `repo_deleted` | `dashboard.repo.deleted` |
| `token_validated` | `auth.token.validated` |

### New events

- `landing.cta.hero_click`, `landing.generate_pat.click`, `auth.token.failed`, `dashboard.batch.completed`, `dashboard.batch.stopped`, `dashboard.user.logout`

### Bug fixes

- `token_validated` triple-fire: removed from `token-form-section.tsx` and `get-started-section.tsx`, kept only in provider `onSuccess`
- Removed `tokenValidatedRef` from provider (once-per-session now handled by analytics registry)
- Batch abort delay: skip 1s sleep when `abortRef.current` is true

## Type of change

- [x] Bug fix
- [x] New feature
- [x] Refactor

## Checklist

- [x] `bun run lint` passes
- [x] `bun run test:unit` passes (393/393)
- [x] `bun run build` succeeds
- [x] New components have co-located tests
- [x] Uses semantic color classes (not hardcoded Tailwind colors)
- [x] Type-only imports for `@octokit/*` types