### PR TITLE
feat(seo): fix GSC indexing — www/HTTP redirects + canonical header

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -29,6 +29,7 @@
       },
       "devDependencies": {
         "@argos-ci/playwright": "^6.6.0",
+        "@cloudflare/workers-types": "^4.20260413.1",
         "@octokit/graphql-schema": "^15.26.1",
         "@playwright/test": "^1.58.2",
         "@resvg/resvg-js": "^2.6.2",
@@ -158,6 +159,8 @@
     "@cloudflare/workerd-linux-arm64": ["@cloudflare/workerd-linux-arm64@1.20260317.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-3QrNnPF1xlaNwkHpasvRvAMidOvQs2NhXQmALJrEfpIJ/IDL2la8g499yXp3eqhG3hVMCB07XVY149GTs42Xtw=="],
 
     "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260317.1", "", { "os": "win32", "cpu": "x64" }, "sha512-MfZTz+7LfuIpMGTa3RLXHX8Z/pnycZLItn94WRdHr8LPVet+C5/1Nzei399w/jr3+kzT4pDKk26JF/tlI5elpQ=="],
+
+    "@cloudflare/workers-types": ["@cloudflare/workers-types@4.20260413.1", "", {}, "sha512-4FFHIVIk645Wf20eCVfe0eM3ERsEw98DFng76QZf1C1JMgIVlfSV2gZF1EyXxNVwOG0RM/CBlu07+u/Z/0Oq9Q=="],
 
     "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -31,5 +31,13 @@ export default [
       },
     },
   },
+  {
+    files: ["worker/**/*.ts"],
+    languageOptions: {
+      parserOptions: {
+        project: "./tsconfig.worker.json",
+      },
+    },
+  },
   prettier,
 ];

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
   },
   "devDependencies": {
     "@argos-ci/playwright": "^6.6.0",
+    "@cloudflare/workers-types": "^4.20260413.1",
     "@octokit/graphql-schema": "^15.26.1",
     "@playwright/test": "^1.58.2",
     "@resvg/resvg-js": "^2.6.2",

--- a/public/_headers
+++ b/public/_headers
@@ -1,3 +1,6 @@
+/
+  Link: <https://reporemover.xyz/>; rel="canonical"
+
 /*
   X-Frame-Options: DENY
   X-Content-Type-Options: nosniff

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
   "files": [],
   "references": [
     { "path": "./tsconfig.app.json" },
-    { "path": "./tsconfig.node.json" }
+    { "path": "./tsconfig.node.json" },
+    { "path": "./tsconfig.worker.json" }
   ]
 }

--- a/tsconfig.worker.json
+++ b/tsconfig.worker.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "incremental": true,
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.worker.tsbuildinfo",
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "types": ["@cloudflare/workers-types"],
+    "noEmit": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["worker"]
+}

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -1,0 +1,30 @@
+interface Env {
+  ASSETS: Fetcher;
+}
+
+const CANONICAL_HOST = "reporemover.xyz";
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const url = new URL(request.url);
+    let shouldRedirect = false;
+
+    // Force HTTPS
+    if (url.protocol === "http:") {
+      url.protocol = "https:";
+      shouldRedirect = true;
+    }
+
+    // Redirect www to non-www
+    if (url.hostname === `www.${CANONICAL_HOST}`) {
+      url.hostname = CANONICAL_HOST;
+      shouldRedirect = true;
+    }
+
+    if (shouldRedirect) {
+      return Response.redirect(url.toString(), 301);
+    }
+
+    return env.ASSETS.fetch(request);
+  },
+} satisfies ExportedHandler<Env>;

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,6 +1,7 @@
 {
   "$schema": "node_modules/wrangler/config-schema.json",
   "name": "repo-remover",
+  "main": "worker/index.ts",
   "compatibility_date": "2025-01-01",
   "workers_dev": true,
   "preview_urls": true,
@@ -9,6 +10,7 @@
   },
   "assets": {
     "directory": "dist",
+    "binding": "ASSETS",
     "not_found_handling": "single-page-application"
   }
 }


### PR DESCRIPTION
## Summary
- Add Cloudflare Worker to 301 redirect `www.reporemover.xyz` → `reporemover.xyz` and `http://` → `https://`
- Add canonical `Link` HTTP header on `/` (reinforces the existing HTML `<link rel="canonical">` tag)
- Wire worker into `wrangler.jsonc` with `ASSETS` binding for static asset passthrough

Addresses these GSC "Page indexing" issues:
- **Duplicate without user-selected canonical** — query param URLs (`?ref=`, `?utm_source=`) will resolve as Google re-crawls with canonical tag (added in #212)
- **Page with redirect** — referral URL in query param, low priority
- **Alternate page with proper canonical tag** — `http://reporemover.xyz/` now gets 301 to HTTPS
- **Crawled - currently not indexed** — `www.` and `http://www.` variants now get 301 to canonical

## Test plan
- [x] `bun run lint` passes
- [x] `bun run test:unit` — 393 tests pass
- [x] `bun run build` succeeds
- [x] `wrangler dev` serves app correctly (200 OK)
- [x] Deploy to staging and verify:
  - `curl -I http://www.reporemover.xyz` returns 301 to `https://reporemover.xyz`
  - `curl -I https://www.reporemover.xyz` returns 301 to `https://reporemover.xyz`
  - `curl -I https://reporemover.xyz` returns 200 with `Link: <https://reporemover.xyz/>; rel="canonical"` header
- [ ] After deploy, validate fixed issues in GSC

🤖 Generated with [Claude Code](https://claude.com/claude-code)