### PR TITLE
fix(seo): run worker first so redirects actually fire

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -6,6 +6,7 @@ export default [
     ignores: [
       "node_modules/",
       "dist/",
+      ".wrangler/",
       ".vscode/",
       "out/",
       "vitest.setup.ts",

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -11,6 +11,7 @@
   "assets": {
     "directory": "dist",
     "binding": "ASSETS",
-    "not_found_handling": "single-page-application"
+    "not_found_handling": "single-page-application",
+    "run_worker_first": true
   }
 }


### PR DESCRIPTION
## Summary
Follow-up to #218. The worker's HTTP→HTTPS redirect never ran in production because Cloudflare Workers Static Assets serves matching assets (e.g. `/` → `index.html`) **without invoking the worker by default**.

Setting `run_worker_first: true` forces every request to hit the worker first. The worker still passes through to `env.ASSETS.fetch()` when no redirect is needed.

Also configured via Cloudflare API (out of band):
- Added `www.reporemover.xyz` as a worker custom domain (creates DNS + cert + worker route). The worker will 301 www → non-www once this PR deploys.

Still `off` at zone level (requires dashboard access): "Always Use HTTPS". Not needed once this PR ships — the worker handles it.

## Test plan
- [x] `bun run lint` passes
- [x] `bun run build` passes
- [x] `npx tsc -b` passes
- [ ] After deploy, verify:
  - `curl -I http://reporemover.xyz/` → 301 to `https://reporemover.xyz/`
  - `curl -I https://www.reporemover.xyz/` → 301 to `https://reporemover.xyz/`
  - `curl -I https://reporemover.xyz/` → 200 + Link canonical header
- [ ] Re-request GSC validation for all 4 indexing issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)