### PR TITLE
docs: add Argos visual testing badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Bulk view, archive, and delete your GitHub repositories. Zero-knowledge — ever
   </a>
 </p>
 
+[![Covered by Argos Visual Testing](https://argos-ci.com/badge.svg)](https://app.argos-ci.com/moollaza/repo-remover/reference)
+
 ## How it works
 
 Repo Remover uses a [Personal Access Token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens) with the GitHub API to list your repositories and make changes to them.

--- a/README.md
+++ b/README.md
@@ -9,9 +9,10 @@ Bulk view, archive, and delete your GitHub repositories. Zero-knowledge — ever
   <a href="https://reporemover.xyz">
     <img src="https://img.shields.io/website/https/reporemover.xyz.svg?style=flat-square" >
   </a>
+  <a href="https://app.argos-ci.com/moollaza/repo-remover/reference">
+    <img src="https://argos-ci.com/badge.svg" >
+  </a>
 </p>
-
-[![Covered by Argos Visual Testing](https://argos-ci.com/badge.svg)](https://app.argos-ci.com/moollaza/repo-remover/reference)
 
 ## How it works
 


### PR DESCRIPTION
## Summary

Add Argos visual testing badge to the README, linking to the reference baseline on argos-ci.com. This is the final piece after wiring Argos into Playwright + CI — now visible to anyone landing on the repo.

## Type of change

- [x] Documentation

## Checklist

- [x] `bun run lint` passes
- [ ] `bun run test:unit` passes (N/A — README-only)
- [ ] `bun run build` succeeds (N/A — README-only)
- [ ] New components have co-located tests (N/A)
- [ ] Uses semantic color classes (not hardcoded Tailwind colors) (N/A)
- [ ] Type-only imports for `@octokit/*` types (N/A)