### PR TITLE
fix(seo): Cloudflare Worker for redirects and canonical header

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,24 @@ Plans go in `docs/plans/`. Solutions go in `docs/solutions/`.
 - **Error monitoring**: Sentry (with token sanitization + PII scrubbing)
 - **Analytics**: Fathom (privacy-first, no cookies)
 
+## Load-bearing SEO infrastructure — do not touch without approval
+
+The Cloudflare Worker at `worker/index.ts` is required for SEO and must not be deleted, disabled, or "cleaned up as unused." It performs three jobs that nothing else in the stack covers:
+
+1. `http://` → `https://` 301 redirects
+2. `www.reporemover.xyz` → `reporemover.xyz` 301 redirects
+3. Injects `Link: <https://reporemover.xyz/>; rel="canonical"` on every `/` response, including query-string variants like `/?ref=producthunt`, `/?utm_source=…`, `/?from=…` (the static `_headers` file can only match exact paths and cannot cover these)
+
+All of the following are mutually dependent — removing any one silently breaks production SEO and GSC will regress within days:
+
+- `worker/index.ts` (+ `worker/index.test.ts` — regression suite)
+- `tsconfig.worker.json` and its reference in `tsconfig.json`
+- `wrangler.jsonc` keys: `main: "worker/index.ts"`, `assets.binding: "ASSETS"`, `assets.run_worker_first: true`
+- `@cloudflare/workers-types` in `devDependencies` (CI's `--frozen-lockfile` skips optional peer deps, so declare it explicitly)
+- `eslint.config.js` worker `parserOptions` override for `worker/**/*.ts`
+
+If a task genuinely requires changing any of these, stop and confirm with the user first.
+
 ## Coding Standards
 
 - Use Tailwind utility classes (not hardcoded colors). Use CSS custom properties for theme values

--- a/bun.lock
+++ b/bun.lock
@@ -29,6 +29,7 @@
       },
       "devDependencies": {
         "@argos-ci/playwright": "^6.6.0",
+        "@cloudflare/workers-types": "^4.20260413.1",
         "@octokit/graphql-schema": "^15.26.1",
         "@playwright/test": "^1.58.2",
         "@resvg/resvg-js": "^2.6.2",
@@ -162,6 +163,8 @@
     "@cloudflare/workerd-linux-arm64": ["@cloudflare/workerd-linux-arm64@1.20260317.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-3QrNnPF1xlaNwkHpasvRvAMidOvQs2NhXQmALJrEfpIJ/IDL2la8g499yXp3eqhG3hVMCB07XVY149GTs42Xtw=="],
 
     "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260317.1", "", { "os": "win32", "cpu": "x64" }, "sha512-MfZTz+7LfuIpMGTa3RLXHX8Z/pnycZLItn94WRdHr8LPVet+C5/1Nzei399w/jr3+kzT4pDKk26JF/tlI5elpQ=="],
+
+    "@cloudflare/workers-types": ["@cloudflare/workers-types@4.20260418.1", "", {}, "sha512-bywXb2XmeSqrLCQYipcupLneqx015YhhNWz2v9b9iatpe8Cg551vP7ZuD5S2a6GfBka0dDnO70kIBiBvFglcrg=="],
 
     "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -6,6 +6,7 @@ export default [
     ignores: [
       "node_modules/",
       "dist/",
+      ".wrangler/",
       ".vscode/",
       "out/",
       "vitest.setup.ts",
@@ -28,6 +29,14 @@ export default [
     languageOptions: {
       parserOptions: {
         project: "./tsconfig.app.json",
+      },
+    },
+  },
+  {
+    files: ["worker/**/*.ts"],
+    languageOptions: {
+      parserOptions: {
+        project: "./tsconfig.worker.json",
       },
     },
   },

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
   },
   "devDependencies": {
     "@argos-ci/playwright": "^6.6.0",
+    "@cloudflare/workers-types": "^4.20260413.1",
     "@octokit/graphql-schema": "^15.26.1",
     "@playwright/test": "^1.58.2",
     "@resvg/resvg-js": "^2.6.2",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
   "files": [],
   "references": [
     { "path": "./tsconfig.app.json" },
-    { "path": "./tsconfig.node.json" }
+    { "path": "./tsconfig.node.json" },
+    { "path": "./tsconfig.worker.json" }
   ]
 }

--- a/tsconfig.worker.json
+++ b/tsconfig.worker.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "incremental": true,
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.worker.tsbuildinfo",
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "types": ["@cloudflare/workers-types"],
+    "noEmit": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["worker"]
+}

--- a/worker/index.test.ts
+++ b/worker/index.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import worker from "./index";
+
+// Minimal fetcher stub for `env.ASSETS.fetch(request)` — returns a plain 200
+// response so we can assert what the worker wraps around it.
+const env = {
+  ASSETS: {
+    fetch: async () =>
+      new Response("<!doctype html>", {
+        status: 200,
+        headers: { "Content-Type": "text/html" },
+      }),
+  },
+} as unknown as Parameters<typeof worker.fetch>[1];
+
+const call = (url: string) => worker.fetch(new Request(url, { redirect: "manual" }), env);
+
+describe("worker redirects", () => {
+  it("301s http to https", async () => {
+    const res = await call("http://reporemover.xyz/");
+    expect(res.status).toBe(301);
+    expect(res.headers.get("Location")).toBe("https://reporemover.xyz/");
+  });
+
+  it("301s www to apex", async () => {
+    const res = await call("https://www.reporemover.xyz/");
+    expect(res.status).toBe(301);
+    expect(res.headers.get("Location")).toBe("https://reporemover.xyz/");
+  });
+
+  it("301s http+www in a single hop", async () => {
+    const res = await call("http://www.reporemover.xyz/");
+    expect(res.status).toBe(301);
+    expect(res.headers.get("Location")).toBe("https://reporemover.xyz/");
+  });
+
+  it("preserves path and query on redirect", async () => {
+    const res = await call("http://www.reporemover.xyz/dashboard?foo=bar");
+    expect(res.status).toBe(301);
+    expect(res.headers.get("Location")).toBe("https://reporemover.xyz/dashboard?foo=bar");
+  });
+});
+
+describe("canonical Link header", () => {
+  it("emits canonical Link on the clean homepage", async () => {
+    const res = await call("https://reporemover.xyz/");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Link")).toBe('<https://reporemover.xyz/>; rel="canonical"');
+  });
+
+  it.each([
+    "https://reporemover.xyz/?ref=example1",
+    "https://reporemover.xyz/?utm_source=example2",
+    "https://reporemover.xyz/?from=example3.com",
+    "https://reporemover.xyz/?ref=https%3A%2F%2Fexample4.com",
+  ])("emits canonical Link for homepage query-string variant %s", async (url) => {
+    const res = await call(url);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Link")).toBe('<https://reporemover.xyz/>; rel="canonical"');
+  });
+
+  it("does NOT emit canonical Link on non-homepage paths", async () => {
+    const res = await call("https://reporemover.xyz/dashboard");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Link")).toBeNull();
+  });
+
+  it("does NOT emit canonical Link on /guides", async () => {
+    const res = await call("https://reporemover.xyz/guides/bulk-delete-github-repositories/");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Link")).toBeNull();
+  });
+});

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -1,0 +1,46 @@
+interface Env {
+  ASSETS: Fetcher;
+}
+
+const CANONICAL_HOST = "reporemover.xyz";
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const url = new URL(request.url);
+    let shouldRedirect = false;
+
+    // Force HTTPS
+    if (url.protocol === "http:") {
+      url.protocol = "https:";
+      shouldRedirect = true;
+    }
+
+    // Redirect www to non-www
+    if (url.hostname === `www.${CANONICAL_HOST}`) {
+      url.hostname = CANONICAL_HOST;
+      shouldRedirect = true;
+    }
+
+    if (shouldRedirect) {
+      return Response.redirect(url.toString(), 301);
+    }
+
+    const response = await env.ASSETS.fetch(request);
+
+    // Emit canonical Link header on every homepage response, regardless of
+    // query string — covers inbound tracking variants (`/?ref=…`,
+    // `/?utm_source=…`, `/?from=…`) that GSC was flagging as
+    // "Duplicate without user-selected canonical".
+    if (url.pathname === "/") {
+      const headers = new Headers(response.headers);
+      headers.set("Link", `<https://${CANONICAL_HOST}/>; rel="canonical"`);
+      return new Response(response.body, {
+        status: response.status,
+        statusText: response.statusText,
+        headers,
+      });
+    }
+
+    return response;
+  },
+} satisfies ExportedHandler<Env>;

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,6 +1,7 @@
 {
   "$schema": "node_modules/wrangler/config-schema.json",
   "name": "repo-remover",
+  "main": "worker/index.ts",
   "compatibility_date": "2025-01-01",
   "workers_dev": true,
   "preview_urls": true,
@@ -9,6 +10,8 @@
   },
   "assets": {
     "directory": "dist",
-    "not_found_handling": "single-page-application"
+    "binding": "ASSETS",
+    "not_found_handling": "single-page-application",
+    "run_worker_first": true
   }
 }


### PR DESCRIPTION
## Summary

Adds a Cloudflare Worker that handles SEO-critical routing at the edge:

- `http://` → `https://` 301 redirects
- `www.reporemover.xyz` → `reporemover.xyz` 301 redirects
- Emits `Link: <https://reporemover.xyz/>; rel="canonical"` on every homepage response, including query-string variants (covers inbound tracking params like `?ref=…`, `?utm_source=…`, `?from=…` that `public/_headers` cannot match because it only supports exact-path rules)

Ships with `worker/index.test.ts` (11 cases) locking in the four contracts so future changes can't regress behavior silently. Declares `@cloudflare/workers-types` as an explicit devDependency so CI's `--frozen-lockfile` install picks it up, and documents the interlocking files in `CLAUDE.md` under **Load-bearing SEO infrastructure**.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [ ] Other (describe below)

## Checklist

- [x] `bun run lint` passes
- [x] `bun run test:unit` passes (420 tests)
- [x] `bun run build` succeeds
- [ ] New components have co-located tests
- [ ] Uses semantic color classes (not hardcoded Tailwind colors)
- [ ] Type-only imports for `@octokit/*` types