### PR TITLE
fix: tighten analytics CSP

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -5,4 +5,4 @@
   Referrer-Policy: strict-origin-when-cross-origin
   Permissions-Policy: camera=(), microphone=(), geolocation=(), interest-cohort=()
   Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
-  Content-Security-Policy: default-src 'self'; script-src 'self' https://cdn.usefathom.com; connect-src 'self' https://api.github.com https://*.ingest.sentry.io https://*.usefathom.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https://avatars.githubusercontent.com https://api.producthunt.com; frame-ancestors 'none'
+  Content-Security-Policy: default-src 'self'; script-src 'self' https://cdn.usefathom.com; connect-src 'self' https://api.github.com https://*.ingest.sentry.io https://*.usefathom.com; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data: https://avatars.githubusercontent.com https://api.producthunt.com https://cdn.usefathom.com; frame-ancestors 'none'


### PR DESCRIPTION
## Summary

Allows Fathom pageview beacon image requests by adding `https://cdn.usefathom.com` to `img-src`. Also removes stale Google Fonts allowances from `style-src` and `font-src`; the app does not load Google Fonts, and the CSP should not permit that privacy-sensitive connection path.

Verified the production build regenerates `dist/_headers` with the tightened directive.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Checklist

- [x] `bun run lint` passes
- [x] `bun run test:unit` passes
- [x] `bun run build` succeeds
- [x] New components have co-located tests (N/A, no components)
- [x] Uses semantic color classes (N/A, no UI changes)
- [x] Type-only imports for `@octokit/*` types (N/A, no TypeScript imports)