### PR TITLE
fix(ci): use bun dependabot ecosystem so bun.lock stays in sync

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,9 @@
 version: 2
 updates:
-  - package-ecosystem: "npm"
+  # "bun" (not "npm") — the npm ecosystem does not read or update bun.lock,
+  # so it bumps package.json alone and leaves the lockfile stale, breaking
+  # `bun install --frozen-lockfile` in CI and on Cloudflare Workers Builds.
+  - package-ecosystem: "bun"
     directory: "/"
     schedule:
       interval: "monthly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: 1.3.10
       - name: Install dependencies
         run: bun install --frozen-lockfile
       - name: Lint code
@@ -45,7 +45,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: 1.3.10
       - uses: actions/setup-node@v6
         with:
           node-version: lts/*
@@ -87,7 +87,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: 1.3.10
       - name: Install dependencies
         run: bun install --frozen-lockfile
       - name: Build project


### PR DESCRIPTION
## Summary

Dependabot has been opening dependency PRs that update `package.json` without updating `bun.lock`. Any build running `bun install --frozen-lockfile` then fails with `lockfile had changes, but lockfile is frozen` — this broke Cloudflare Workers Builds on every Dependabot branch.

Root cause: `.github/dependabot.yml` declared `package-ecosystem: "npm"`. The npm ecosystem does not read or update `bun.lock`; Bun has its own ecosystem value, supported since bun >= v1.1.39. Dependabot bumped the manifest, found no `package-lock.json` to update, and left the lockfile stale.

This is not a bun or Cloudflare issue — `bun install --frozen-lockfile` was correctly rejecting a genuine `package.json` / `bun.lock` mismatch.

## Changes

- `dependabot.yml`: `package-ecosystem: "npm"` → `"bun"` for the JS dependency group, with a comment recording why. Grouping, ignore rules, schedule and labels are unchanged; the `github-actions` block is untouched.
- `ci.yml`: pin `bun-version` to `1.3.10` in all three jobs (was `latest`). Unrelated to the bug, but stops CI silently floating bun between runs.

## Why

Every monthly Dependabot batch produced a red deploy and needed a manual `bun install` + commit to unblock. Fixing the ecosystem makes Dependabot maintain the lockfile itself, so `--frozen-lockfile` can stay on and builds remain reproducible.

## How to verify

Ran:
- Confirmed `bun.lock` on `main` is already in sync — `bun install` under bun 1.3.10 reports "no changes", and a from-scratch `rm bun.lock && bun install` reproduces the committed file byte-for-byte.
- Confirmed the same under bun 1.3.14 and under Linux (`oven/bun:1.3.10`) — all clean, ruling out version and platform drift.
- Confirmed `gh pr view 230 --json files` lists `package.json` only, with no `bun.lock` — the direct evidence for the diagnosis.
- Verified against GitHub's supported-ecosystems reference that `bun` is a distinct `package-ecosystem` value and that `npm` does not cover `bun.lock`.

Not run: no source code changes here, so lint/unit/build behavior is unchanged — CI covers them on this PR.

The real test is the next Dependabot PR: it should modify `package.json` **and** `bun.lock` together.

## What to look for

- The `bun` ecosystem value is only valid for bun >= v1.1.39. This repo is on 1.3.10.
- If a future Dependabot PR still touches `package.json` alone, the ecosystem change did not take effect — check the Dependabot run log rather than re-diagnosing the build failure.
- The bun pin in `ci.yml` now needs manual bumping; it will not follow new bun releases.
- Open PR #230 was opened under the old config, so its lockfile was synced by hand and is unaffected by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
