### PR TITLE
fix(ci): hold TypeScript at 6.x, split major updates into their own group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,21 +7,34 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
-    open-pull-requests-limit: 3
+    open-pull-requests-limit: 4
     groups:
       production:
         dependency-type: "production"
         update-types:
-          - "major"
           - "minor"
           - "patch"
+      production-major:
+        dependency-type: "production"
+        update-types:
+          - "major"
       dev-tooling:
         dependency-type: "development"
         update-types:
-          - "major"
           - "minor"
           - "patch"
+      dev-tooling-major:
+        dependency-type: "development"
+        update-types:
+          - "major"
     ignore:
+      # typescript-eslint declares peer `typescript: ">=4.8.4 <6.1.0"`, so TS 7
+      # breaks lint/typecheck outright ('TypeError: Cannot read properties of
+      # undefined (reading 'Cjs')' in typescript-estree). Confirmed in this
+      # repo (#238) and in autobill. Hold until typescript-eslint ships TS >=7
+      # support: https://github.com/typescript-eslint/typescript-eslint/issues/10940
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
       # Type definitions — no runtime impact, only noise
       - dependency-name: "@types/*"
         update-types: ["version-update:semver-minor", "version-update:semver-patch"]


### PR DESCRIPTION
## Summary

PR #238 (dev-tooling, 11 updates) fails `bun run lint`:

```
TypeError: Cannot read properties of undefined (reading 'Cjs')
    at .../node_modules/@typescript-eslint/typescript-estree/dist/create-program/shared.js:59:18
```

The group bundled `typescript` 6.0.2 → 7.0.2 alongside 10 other updates, but `typescript-eslint` declares its peer as `typescript: ">=4.8.4 <6.1.0"` — TS 7 isn't supported yet. The same failure signature turned up independently in moollaza/autobill#86 and (via `svelte-check`) moollaza/uncovr#183, so this is a TypeScript-7-just-shipped problem hitting the fleet, not something specific to this repo.

## Changes

- `ignore` typescript major updates, with a comment and a link to [typescript-eslint#10940](https://github.com/typescript-eslint/typescript-eslint/issues/10940).
- Split `production` and `dev-tooling` into routine (minor/patch) and `-major` sub-groups. `open-pull-requests-limit` bumped 3 → 4 to give the extra groups room.

## Why

The existing groups bundled every update-type together, so one incompatible major (TS 7 here) blocks the other 10 good updates in the same PR indefinitely. Splitting majors into their own group means a bad major arrives alone and can't hold up routine updates — this is the direct cause of #238 not going green.

## How to verify

Ran:
- Confirmed via `gh run view --job ... --log-failed` that the failure is `typescript-estree` choking on the TS 7 API, not a lockfile or test issue.
- Confirmed `typescript` 6.0.2→7.0.2 is the only major-version dependency in #238's diff.
- Cross-checked the identical error signature in autobill (`@typescript-eslint/typescript-estree`) and uncovr (`svelte-check`), both also from a TS 7 bump — ruling out anything repo-specific.

Not run: config-only change, no application code touched.

## What to look for

- #238 is not fixed retroactively — close it and let Dependabot regenerate under the new groups once this merges. The regenerated PR should exclude the typescript bump.
- Revisit the ignore rule when typescript-eslint supports TS 7 — remove it, don't just bump around it.
- `open-pull-requests-limit: 4` may need another bump later if all four groups have updates simultaneously and start getting throttled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
