### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/moollaza/repo-remover/security/code-scanning/7](https://github.com/moollaza/repo-remover/security/code-scanning/7)

Add an explicit `permissions` block at the workflow root so it applies to all jobs (`lint-and-test`, `e2e-tests`, `build`) without changing workflow behavior.  
The best minimal fix here is:

```yml
permissions:
  contents: read
```

This aligns with CodeQL’s recommendation and least privilege for the shown steps (checkout, cache, artifact upload, tests, build). No imports, methods, or dependencies are needed since this is YAML configuration only.

Edit `.github/workflows/ci.yml` near the top-level keys, immediately after the `on:` trigger block (before `concurrency:` is ideal for clarity).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
